### PR TITLE
Add ExtraHeaders to opt_extraInfoSpec to match Chrome 89 requirement

### DIFF
--- a/js/render_iframe.js
+++ b/js/render_iframe.js
@@ -27,5 +27,5 @@ chrome.webRequest.onHeadersReceived.addListener(
         urls: [ '*://*/*' ],
         types: [ 'sub_frame' ]
     },
-    ['blocking', 'responseHeaders']
+    ['blocking', 'responseHeaders', 'extraHeaders']
 );


### PR DESCRIPTION
Starting from Chrome 89, the X-Frame-Options response header cannot be
effectively modified or removed without specifying 'extraHeaders' in
opt_extraInfoSpec.