### PR TITLE
Filter Content-Security-Policy Header

### DIFF
--- a/js/render_iframe.js
+++ b/js/render_iframe.js
@@ -14,14 +14,11 @@ iframeTarget.src = targetUrl;
 
 chrome.webRequest.onHeadersReceived.addListener(
     function(info) {
-        let headers = info.responseHeaders;
-        for (let i = headers.length-1; i >= 0; i--) {
-            const header = headers[i].name.toLowerCase();
-            if (header == 'x-frame-options' || header == 'frame-options') {
-                headers.splice(i, 1);
-            }
-        }
-        return {responseHeaders: headers};
+        const headers = info.responseHeaders;
+        const blockedHeaders = ['x-frame-options', 'frame-options', 'content-security-policy'];
+        const filtredHeaders = headers.filter((header) => !blockedHeaders.includes(header.name.toLowerCase()));
+
+        return {responseHeaders: filtredHeaders};
     },
     {
         urls: [ '*://*/*' ],

--- a/js/render_iframe.js
+++ b/js/render_iframe.js
@@ -9,9 +9,6 @@ const iframe3pts = document.getElementById('app3pts');
 const viewSearch = new URLSearchParams(location.search);
 const targetUrl = decodeURI(viewSearch.get('host'));
 
-iframe3pts.src = "https://3pts.dev";
-iframeTarget.src = targetUrl;
-
 chrome.webRequest.onHeadersReceived.addListener(
     function(info) {
         const headers = info.responseHeaders;
@@ -26,3 +23,6 @@ chrome.webRequest.onHeadersReceived.addListener(
     },
     ['blocking', 'responseHeaders', 'extraHeaders']
 );
+
+iframe3pts.src = "https://3pts.dev";
+iframeTarget.src = targetUrl;


### PR DESCRIPTION
Fix issue with github.com

Github HTTP response has the Content-Security-Policy header and the directive ` frame-ancestors` equal to `none`, this directive doesn't allow loading the GitHub page as an iframe.